### PR TITLE
Fix: Set access in changelog config to public

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "version": "changeset version",
     "postversion": "git add . && git commit -m 'chore(release): version bump' && git push --follow-tags",
-    "changeset:release": "changeset publish --access public",
+    "changeset:release": "changeset publish",
     "changeset:gen": "npx changeset"
   },
   "keywords": [


### PR DESCRIPTION
This pull request modifies the configuration for publishing packages, making the access level public and simplifying the release script. These changes align with a shift to public accessibility for the package.

Changes to publishing configuration:

* [`.changeset/config.json`](diffhunk://#diff-ed5b41335ff968c5cfd8035d4b8f8c8c0538b6746182d522adb0312eb9137fc5L7-R7): Updated the `access` property from `"restricted"` to `"public"`, allowing packages to be publicly accessible.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L11-R11): Simplified the `changeset:release` script by removing the `--access public` flag, as the access level is now configured in `.changeset/config.json`.